### PR TITLE
Add endpoint for getting all the spell metadata names for later searching

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 	r.HandleFunc("/spells", spellService.PostSpellHandler).Methods("POST")
 	r.HandleFunc("/spells", spellService.GetAllSpellHandler).Methods("GET")
 	r.HandleFunc("/spellmetadata/{name}", spellService.GetSpellMetadataHandler).Methods("GET")
+	r.HandleFunc("/spellmetadata", spellService.GetAllSpellMetadataHandler).Methods("GET")
 
 	// Bind to a port and pass our router in
 	port := os.Getenv("PORT")


### PR DESCRIPTION
The grouping should be handled by the DB query but CosmosDB doesn't appear to support
the group aggregation operation so the grouping needs to be done in the service instead.
There is still an issue of upper and lower case names being different but that is to be
solved separately.